### PR TITLE
comment LEPRIKON_DOMAIN by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ mkdir leprikon && cd leprikon
 # download docker-compose configuration
 wget https://raw.githubusercontent.com/leprikon-cz/leprikon/master/docker-compose.yml
 
+# if your instance is exposed to the internet and dns record pointed to your IP you can uncomment line LEPRIKON_DOMAIN and change to your desired domain.
+# then Lets Encrypt certificate will be automatically generated for your domain
+# if you want to use reverse proxy or only for testing then leave as is
+
 # start the application containers
 # (you need docker-compose installed and docker service running)
 sudo docker-compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       EMAIL_HOST_USER: leprikon
       EMAIL_HOST_PASSWORD: EMAIL_HOST_PASSWORD
       EMAIL_SUBJECT_PREFIX: '[Leprikón]'
-      LEPRIKON_DOMAIN: example.leprikon.cz
+      #LEPRIKON_DOMAIN: your.domain.local
       CACHE_LOCATION: unix:///var/run/redis/redis.sock
       SECRET_KEY: SECRET_KEY
       SERVER_EMAIL: '"Leprikón <leprikon@leprikon.cz>"'


### PR DESCRIPTION
If you run docker-compose up with default config without your instance being exposed to the internet and your dns correctly setup then leprikon will fail to start because nginx expects certificates but there are none.

I have also changed the domain because if you read the logs and supply certificates manually the 404 page of leprikon.cz will be shown which is confusing, you may assume that something is wrong with your leprikon (it took me a while to realize this was redirect).

I have also added more information about this to README.md