### PR TITLE
Aktualizace kontejneru s Postfixem

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       - ./mysql:/var/lib/mysql
 
   smtp:
-    image: catatnight/postfix
+    image: panmourovaty/postfix
     environment:
       maildomain: leprikon.cz
       smtp_user: leprikon:EMAIL_HOST_PASSWORD


### PR DESCRIPTION
Současně používaný kontejner catatnight/postfix běží na verzi ubuntu 14.04 ta sice bude podporována ještě rok ale kontejner nebyl aktualizovaný už hodně dlouho (7 let) takže neobsahuje nové bezpečnostní záplaty a vzhledem k ostatním projektům autora nic nenaznačuje další aktualizace.

Projekt naštěstí je na githubu (https://github.com/catatnight/docker-postfix) tak jsem ho forknul (https://github.com/panmourovaty/docker-postfix), nahradil pár deprecated věcí, aktualizoval na ubuntu 22.04 a nastavil github action aby se periodicky aktualizoval.

Zkoušel jsem nasadit u sebe a poté na svcletovice.cz a vše proběhlo hladce ale nevyzkoušel jsem zatím vše (nevím kde najít některé funkce co posílají emaily).

Jestli budeš mít zájem můžeme přesunout můj repozitář pod organizaci leprikon-cz aby jsi k němu měl také přístup.